### PR TITLE
Newsletter images option 1

### DIFF
--- a/the-pulse/newsletter/index.qmd
+++ b/the-pulse/newsletter/index.qmd
@@ -7,7 +7,6 @@ description: |
 listing:
   template: rssdsai-newsletter.ejs
   contents: rssdsai-newsletter.yml
-  fields: [date, title]
   sort-ui: true
   filter-ui: true
   page-size: 12

--- a/the-pulse/newsletter/rssdsai-newsletter.ejs
+++ b/the-pulse/newsletter/rssdsai-newsletter.ejs
@@ -2,7 +2,7 @@
 <div class="list">
   <% for (const item of items) { %>
     <div <%= metadataAttrs(item) %>>
-      <!-- <div class="style">
+      <div class="style">
         <style>
           img {
             float: left;
@@ -10,16 +10,16 @@
             margin-right: 15px;
             margin-bottom: 5px;
           }
-        </style> -->
-        <!-- <% if (item.image) { %>
+        </style>
+        <% if (item.image) { %>
         <a href="<%- item.href %>">
           <img src="<%- item.image %>" width="150" alt="<%- item.alt %>" />
         </a>
-        <% } %> -->
+        <% } %>
       <a href="<%- item.href %>" class="listing-title"><b><%= item.title %></a></b><br/>
       <%= item.intro %></br>
       </br>
-      <!-- </div> -->
+    </div>
     </div>
   <% } %>
 </div>

--- a/the-pulse/newsletter/rssdsai-newsletter.yml
+++ b/the-pulse/newsletter/rssdsai-newsletter.yml
@@ -2,6 +2,8 @@
   intro: Well, I don't know about you, but February was a bit of a blur even with the extra day -- we should be used to it now I guess -- certainly less confusing than Julius Caesar's 445 day long 'year of confusion' in 46 B.C. ... Progress of sorts! Definitely time to lose ourselves in some some thought provoking AI and Data Science reading materials!
   href: https://rssdsaisection.substack.com/p/march-newsletter-4f2
   date: 03/01/2024
+  image: https://substackcdn.com/image/fetch/$s_!m2EF!,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F104992b6-be44-40be-a57a-818743f5371b_2048x1298.png
+  alt: Alt texts
 
 - title: "February 2024"
   intro: Well, we've made it through January... continuing violence in the Middle East and Ukraine, depressingly ineffective politics set against a backdrop of dramatically fluctuating temperatures (at least in the UK)... Definitely time to lose ourselves in some thought provoking AI and Data Science reading materials!


### PR DESCRIPTION
If you remove the comments from `rssdsai-newsletter.ejs`, nothing happens. That's because it's looking for an `image:` and `alt:` item for each newsletter in the `rssdsai-newsletter.yml` file.When I uncommented the code, and added those lines w.g.

```
- title: "March 2024" 
  intro: Well, I don't know about you, but February was a bit of a blur even with the extra day 
  href: https://rssdsaisection.substack.com/p/march-newsletter-4f2
  date: 03/01/2024
  image: https://substackcdn.com/image/fetch/$s_!m2EF!,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F104992b6-be44-40be-a57a-818743f5371b_2048x1298.png 
  alt: Some example alt text
```

I get the following.

<img width="2919" height="1337" alt="Screenshot from 2025-09-13 22-01-30" src="https://github.com/user-attachments/assets/721eeb7f-a625-44ef-a97a-763e52d97d1d" />

As you can see this isn't really inline with the rest of the RWDS styling. That's because the newsletter uses a custom template.